### PR TITLE
fix padding mode in artcnn

### DIFF
--- a/traiNNer/archs/artcnn_arch.py
+++ b/traiNNer/archs/artcnn_arch.py
@@ -10,7 +10,7 @@ class DepthToSpace(nn.Module):
         super().__init__()
 
         self.upscale = nn.Sequential(
-            nn.Conv2d(filters, out_ch * (scale**2), kernel_size, 1, kernel_size // 2, padding='same'),
+            nn.Conv2d(filters, out_ch * (scale**2), kernel_size, 1, padding='same'),
             nn.PixelShuffle(scale),
         )
 
@@ -23,7 +23,7 @@ class ActConv(nn.Sequential):
         self, filters: int, kernel_size: int, act: type[nn.Module] = nn.ReLU
     ) -> None:
         super().__init__(
-            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same'), act()
+            nn.Conv2d(filters, filters, kernel_size, 1, padding='same'), act()
         )
 
 
@@ -35,7 +35,7 @@ class ResBlock(nn.Module):
         self.conv = nn.Sequential(
             ActConv(filters, kernel_size, act),
             ActConv(filters, kernel_size, act),
-            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same'),
+            nn.Conv2d(filters, filters, kernel_size, 1, padding='same'),
         )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -55,10 +55,11 @@ class ArtCNN(nn.Module):
         act: type[nn.Module] = nn.ReLU,
     ) -> None:
         super().__init__()
-        self.conv0 = nn.Conv2d(in_ch, filters, kernel_size, 1, kernel_size // 2, padding='same')
+        
+        self.conv0 = nn.Conv2d(in_ch, filters, kernel_size, 1, padding='same')
         self.res_block = nn.Sequential(
             *[ResBlock(filters, kernel_size, act) for _ in range(n_block)]
-            + [nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same')]
+            + [nn.Conv2d(filters, filters, kernel_size, 1, padding='same')]
         )
         self.depth_to_space = DepthToSpace(filters, in_ch, kernel_size, scale)
 

--- a/traiNNer/archs/artcnn_arch.py
+++ b/traiNNer/archs/artcnn_arch.py
@@ -10,7 +10,7 @@ class DepthToSpace(nn.Module):
         super().__init__()
 
         self.upscale = nn.Sequential(
-            nn.Conv2d(filters, out_ch * (scale**2), kernel_size, 1, kernel_size // 2),
+            nn.Conv2d(filters, out_ch * (scale**2), kernel_size, 1, kernel_size // 2, padding='same'),
             nn.PixelShuffle(scale),
         )
 
@@ -23,7 +23,7 @@ class ActConv(nn.Sequential):
         self, filters: int, kernel_size: int, act: type[nn.Module] = nn.ReLU
     ) -> None:
         super().__init__(
-            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2), act()
+            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same'), act()
         )
 
 
@@ -35,7 +35,7 @@ class ResBlock(nn.Module):
         self.conv = nn.Sequential(
             ActConv(filters, kernel_size, act),
             ActConv(filters, kernel_size, act),
-            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2),
+            nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same'),
         )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -55,10 +55,10 @@ class ArtCNN(nn.Module):
         act: type[nn.Module] = nn.ReLU,
     ) -> None:
         super().__init__()
-        self.conv0 = nn.Conv2d(in_ch, filters, kernel_size, 1, kernel_size // 2)
+        self.conv0 = nn.Conv2d(in_ch, filters, kernel_size, 1, kernel_size // 2, padding='same')
         self.res_block = nn.Sequential(
             *[ResBlock(filters, kernel_size, act) for _ in range(n_block)]
-            + [nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2)]
+            + [nn.Conv2d(filters, filters, kernel_size, 1, kernel_size // 2, padding='same')]
         )
         self.depth_to_space = DepthToSpace(filters, in_ch, kernel_size, scale)
 


### PR DESCRIPTION
I somehow made a mistake a long time ago, now the official [implementation](https://github.com/Artoriuz/ArtCNN/blob/main/Notebooks/ArtCNN_R_PyTorch.ipynb) has come out, and I noticed it. I’m actually not sure that they even launched it, in terms of 

```
self.feats_conv = nn.Conv2d(filters, 4, kernel_size=kernel_size, padding='same')
self.pixel_shuffle = nn.PixelShuffle(upscale_factor)
```
it doesn't work that way

