### PR TITLE
Fix tensor shape mismatch in lpips

### DIFF
--- a/traiNNer/archs/lpips_arch.py
+++ b/traiNNer/archs/lpips_arch.py
@@ -341,7 +341,7 @@ class LPIPS(nn.Module):
                 for kk in range(self.L)
             ]
 
-        val = torch.tensor(0, device=res[0].device)
+        val = torch.zeros((1, 1, 1, 1), device=res[0].device)
         for l in range(self.L):
             val += res[l]
 


### PR DESCRIPTION
Tensor shape mismatch occurs in the forward pass of the LPIPS module. Can be resolved by initializing the `val` tensor with a shape of [1, 1, 1, 1].