### PR TITLE
Fix basic_loss.py HSLuvLoss hue difference

### DIFF
--- a/traiNNer/losses/basic_loss.py
+++ b/traiNNer/losses/basic_loss.py
@@ -371,7 +371,7 @@ class HSLuvLoss(nn.Module):
         # hue diff between black or white is 0
         hue_diff = torch.where((x_lightness < eps) & (y_lightness < eps), 0, hue_diff)
         hue_diff = torch.where(
-            (x_lightness > 1 - eps) & (y_lightness > eps - 1), 0, hue_diff
+            (x_lightness > 1 - eps) & (y_lightness > 1 - eps), 0, hue_diff
         )
 
         hue_loss = torch.mean(hue_diff) * self.hue_weight


### PR DESCRIPTION
With:
eps = 0.1
y_lightness normalized to (0.0, 1.0)

y_lightness > eps - 1 is equal to y_lightness > -0.9.
Probably supposed to be y_lightness > 1 - eps.