### PR TITLE
Fix training with 16-bit (or higher) images due to forced uint8 conversion

### DIFF
--- a/traiNNer/data/transforms.py
+++ b/traiNNer/data/transforms.py
@@ -9,6 +9,23 @@ from torch import Tensor
 from traiNNer.utils.img_util import img2rgb
 
 
+VIPS_FORMAT_TO_DTYPE: dict[str, np.dtype] = {
+    "uchar": np.uint8,
+    "char": np.int8,
+    "ushort": np.uint16,
+    "short": np.int16,
+    "uint": np.uint32,
+    "int": np.int32,
+    "float": np.float32,
+    "double": np.float64,
+}
+
+def get_vips_dtype(img: pyvips.Image) -> np.dtype:
+    if img.format not in VIPS_FORMAT_TO_DTYPE:
+        raise ValueError(f"Unsupported VIPS format: {img.format}. Supported formats: {list(VIPS_FORMAT_TO_DTYPE.keys())}")
+    return VIPS_FORMAT_TO_DTYPE[img.format]
+
+
 def mod_crop(img: np.ndarray, scale: int) -> np.ndarray:
     """Mod crop images, used during testing.
 
@@ -40,7 +57,7 @@ def single_random_crop_vips(img: pyvips.Image, patch_size: int) -> np.ndarray:
     return img2rgb(
         np.ndarray(
             buffer=data_gt,
-            dtype=np.uint8,
+            dtype=get_vips_dtype(img),
             shape=[patch_size, patch_size, img.bands],  # pyright: ignore
         )
     )
@@ -237,7 +254,7 @@ def single_crop_vips(
     return img2rgb(
         np.ndarray(
             buffer=data,
-            dtype=np.uint8,
+            dtype=get_vips_dtype(img),
             shape=[patch_size, patch_size, img.bands],  # pyright: ignore[reportAssignmentType,reportArgumentType]
         )
     )


### PR DESCRIPTION
While most of the dataloading and training pipeline supports basically any bit depth (data is normalized most of the time anyway), there currently is a hard bottleneck in transforms.py in `single_crop_vips` and `single_random_crop_vips`:

```python
return img2rgb(
    np.ndarray(
        buffer=data,
        dtype=np.uint8, # Forces 0-255 range!
        shape=[patch_size, patch_size, img.bands],
    )
)
```

I added a lookup table to match the right dtype to the image format.
The behavior for 8-bit inputs (`uchar`) is unchanged, `np.uint8` will still be used (no forced up-conversion or anything).
For anything else, a matching dtype is chosen if possible (e.g. `ushort` will now use `np.uint16`).

I have tested, in practice, that this now allows training with higher bit depth datasets. Previously, it was *technically possible* but results would always be garbage because of the forced conversion to uint8.

<img width="760" height="240" alt="image" src="https://github.com/user-attachments/assets/f5345f62-6601-4157-991d-87aa970ea916" />
