### PR TITLE
Ensure icc_transform uses correct bit depth

### DIFF
--- a/traiNNer/utils/img_util.py
+++ b/traiNNer/utils/img_util.py
@@ -330,7 +330,10 @@ def imfrombytes(content: bytes, flag: str = "color", float32: bool = False) -> M
 def vipsimfrompath(path: str) -> pyvips.Image:
     img = pyvips.Image.new_from_file(
         path, access="sequential", fail=True
-    ).icc_transform("srgb")  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
+    )
+    # This might be a bottleneck if training at 32+ bpc is attempted; icc_transform docs only mention 8/16 bit
+    depth = 16 if img.format in ["ushort", "short"] else 8
+    img = img.icc_transform("srgb", depth=depth)  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
     assert isinstance(img, pyvips.Image)
     return img
 


### PR DESCRIPTION
Little addendum to my previous 16-bit fix pull request.
This just makes sure that the icc_transform function uses the correct bit depth.
It *should* automatically use depth=16 for 16-bit images according to the docs but uh, explicit > implicit I guess.