### PR TITLE
Docs: Fix duplicate loss_weight in fftloss, fliploss, ssimloss examples

### DIFF
--- a/docs/source/loss_reference.md
+++ b/docs/source/loss_reference.md
@@ -121,7 +121,6 @@ loss_weight: 1.0
 
 ```yaml
 type: fliploss
-loss_weight: 1.0
 pixels_per_degree: 67.02064327658226
 loss_weight: 1.0
 ```
@@ -292,7 +291,6 @@ loss_weight: 1.0
 
 ```yaml
 type: ssimloss
-loss_weight: 1.0
 channels: 3
 downsample: false
 test_y_channel: true

--- a/docs/source/loss_reference.md
+++ b/docs/source/loss_reference.md
@@ -113,7 +113,6 @@ loss_weight: 1.0
 
 ```yaml
 type: fftloss
-loss_weight: 1.0
 reduction: mean
 loss_weight: 1.0
 ```


### PR DESCRIPTION
`loss_weight` was specified twice in the config example.