### PR TITLE
Proper detection for OOM error instead of matching anything with "CUDA" in it and add missing garbage collection code

### DIFF
--- a/train.py
+++ b/train.py
@@ -431,11 +431,14 @@ def train_pipeline(root_path: str) -> None:
                         current_iter, current_accum_iter, apply_gradient
                     )
                 except RuntimeError as e:
+                    str_e = str(e).lower()
                     # Check to see if its actually the CUDA out of memory error
-                    if "allocate" in str(e) or "CUDA" in str(e):
+                    if "cuda out of memory" in str_e:
                         # Collect garbage (clear VRAM)
+                        gc.collect()
+                        torch.cuda.empty_cache()
                         raise RuntimeError(
-                            "Ran out of VRAM during training. Please reduce lq_size or batch_size_per_gpu and try again."
+                            "Ran out of VRAM during training. Reduce lq_size or batch_size_per_gpu and try again. Ensure that no other VRAM-intensive programs are running."
                         ) from None
                     else:
                         # Re-raise the exception if not an OOM error


### PR DESCRIPTION
Currently, this code is used to check for CUDA OOM messages:

```python
if "allocate" in str(e) or "CUDA" in str(e):
```

This is extremely crude and frequently falsely detects other errors as OOMs.
For example, **every CUDA error** such as `CUDA error: device-side assert triggered` is treated as an OOM.
The check for `allocate` also means it could trigger when system RAM could not be allocated, but the message is about VRAM.

Additionally, the code has a comment saying `# Collect garbage (clear VRAM)` - which is not implemented, the branch only raises a RuntimeError.

I changed the check to a lowercase check against `cuda out of memory` (reliable for any recent torch version) to actually only catch OOMs as described in the comment above: `# Check to see if its actually the CUDA out of memory error`.
I added `str_e = str(e).lower()` to match against, so it can be reused if additional checks are added, currently OOMs are the only one with a specific message.

I also took the liberty of adding the hint `Ensure that no other VRAM-intensive programs are running.` to the error message, just in case someone forgot to close a game or has another ML workload, e.g. an idling LLM, in VRAM.