### PR TITLE
Don't save checkpoint on Ctrl+C immediately after a scheduled save

### DIFF
--- a/train.py
+++ b/train.py
@@ -519,24 +519,52 @@ def train_pipeline(root_path: str) -> None:
     if train_data is None:
         epoch += 1
 
+    consumed_time = str(datetime.timedelta(seconds=int(time.time() - start_time)))
+
     if interrupt_received:
         # discard partially accumulated iters
         if not apply_gradient or crashed:
             current_iter -= 1
 
         if current_iter > 0:
-            logger.info(
-                "Saving models and training states to %s for epoch: %d, iter: %d.",
-                clickable_file_path(model.opt.path.models, "experiments folder"),
-                epoch,
-                current_iter,
-            )
-            model.save(epoch, current_iter)
+            # Skip redundantly saving another checkpoint on Ctrl+C if the latest
+            # scheduled checkpoint was written less than 60 seconds ago
+            skip_save = False
+            try:
+                models_dir = model.opt.path.models
+                latest_mtime = -1.0
+                for entry in os.scandir(models_dir):
+                    # Validate checkpoint extension and ensure it's not zero-byte
+                    if entry.is_file() and entry.name.rsplit(".", 1)[-1] in ("pth", "safetensors"):
+                        stat = entry.stat()
+                        if stat.st_size > 0 and stat.st_mtime > latest_mtime:
+                            latest_mtime = stat.st_mtime
+                if latest_mtime > 0 and (time.time() - latest_mtime) < 60:
+                    skip_save = True
+            except OSError:
+                skip_save = False
+
+            if skip_save:
+                logger.info(
+                    "A checkpoint in %s was written less than 60 seconds ago; won't save a new one.\n" \
+                    "Stopped at epoch: %d, iter: %d.",
+                    clickable_file_path(model.opt.path.models, "experiments folder"),
+                    epoch,
+                    current_iter,
+                )
+            else:
+                logger.info(
+                    "Saving models and training states to %s for epoch: %d, iter: %d.",
+                    clickable_file_path(model.opt.path.models, "experiments folder"),
+                    epoch,
+                    current_iter,
+                )
+                model.save(epoch, current_iter)
         if model.opt.dist:
             destroy_process_group()
+        logger.info("Training stopped. Time consumed: %s", consumed_time)
         sys.exit(0)
 
-    consumed_time = str(datetime.timedelta(seconds=int(time.time() - start_time)))
     logger.info("End of training. Time consumed: %s", consumed_time)
     logger.info("Save the latest model.")
     model.save(

--- a/train.py
+++ b/train.py
@@ -546,7 +546,7 @@ def train_pipeline(root_path: str) -> None:
 
             if skip_save:
                 logger.info(
-                    "A checkpoint in %s was written less than 60 seconds ago; won't save a new one.\n" \
+                    "A checkpoint in %s was written less than a minute ago; won't save a new one. " \
                     "Stopped at epoch: %d, iter: %d.",
                     clickable_file_path(model.opt.path.models, "experiments folder"),
                     epoch,


### PR DESCRIPTION
I found it pretty annoying that a checkpoint *always* gets saved when doing a graceful exit (Ctrl+C once) of the training.

So I added a check that skips saving a new checkpoint on Ctrl+C if there already is a recent (60 seconds old or less) checkpoint that was created during training.

I also added the `Training stopped. Time consumed: ...` message into the Ctrl+C block (and the `consumed_time` definition above the block) so it gets shown when pausing training, not only when it this the max epochs/iters/whatever else counts as "finished" training.